### PR TITLE
setAlpha changed to setVisibility on flip transformers

### DIFF
--- a/android-viewpager-transformers/src/main/java/com/eftimoff/viewpagertransformers/FlipHorizontalTransformer.java
+++ b/android-viewpager-transformers/src/main/java/com/eftimoff/viewpagertransformers/FlipHorizontalTransformer.java
@@ -24,7 +24,7 @@ public class FlipHorizontalTransformer extends BaseTransformer {
 	protected void onTransform(View view, float position) {
 		final float rotation = 180f * position;
 
-		view.setAlpha(rotation > 90f || rotation < -90f ? 0 : 1);
+		view.setVisibility(rotation > 90f || rotation < -90f ? View.INVISIBLE : View.VISIBLE);
 		view.setPivotX(view.getWidth() * 0.5f);
 		view.setPivotY(view.getHeight() * 0.5f);
 		view.setRotationY(rotation);

--- a/android-viewpager-transformers/src/main/java/com/eftimoff/viewpagertransformers/FlipVerticalTransformer.java
+++ b/android-viewpager-transformers/src/main/java/com/eftimoff/viewpagertransformers/FlipVerticalTransformer.java
@@ -24,7 +24,7 @@ public class FlipVerticalTransformer extends BaseTransformer {
 	protected void onTransform(View view, float position) {
 		final float rotation = -180f * position;
 
-		view.setAlpha(rotation > 90f || rotation < -90f ? 0f : 1f);
+		view.setVisibility(rotation > 90f || rotation < -90f ? View.INVISIBLE : View.VISIBLE);
 		view.setPivotX(view.getWidth() * 0.5f);
 		view.setPivotY(view.getHeight() * 0.5f);
 		view.setRotationX(rotation);


### PR DESCRIPTION
 `setAlpha` changed to `setVisibility` in order to block the functionality of the hidden page
This pull request is related to issue #14 